### PR TITLE
Steal stock fill color

### DIFF
--- a/Objective-C/Tweak.m
+++ b/Objective-C/Tweak.m
@@ -97,6 +97,7 @@ static void new_updateViews(_UIBatteryView *self, SEL _cmd) {
 
 static void new_updateColors(_UIBatteryView *self, SEL _cmd) {
     [self animateViewWithViews:self.fillBar linearBar:self.linearBar currentFillColor:stockColor currentLinearColor:[stockColor colorWithAlphaComponent: 0.5]];
+	[self shouldAnimateChargingBolt];
 }
 
 static void new_shouldAnimateChargingBolt(_UIBatteryView *self, SEL _cmd) {

--- a/Objective-C/Tweak.m
+++ b/Objective-C/Tweak.m
@@ -155,12 +155,12 @@ static void overrideSetText(_UIStatusBarStringView *self, SEL _cmd, NSString *te
 static BOOL overrideSSB(_UIBatteryView *self, SEL _cmd) { return NO; }
 
 // - (id)_batteryFillColor;
-static UIColor* (*origBatteryFillColor)(_UIBatteryView *self, SEL _cmd);
+static UIColor* (*origBFC)(_UIBatteryView *self, SEL _cmd);
 
 static id overrideBFC(_UIBatteryView *self, SEL _cmd) {
     // The alpha value is set here because iOS sometimes makes it semi-transparent
     // Without this it would look funny in wireless carplay.
-	stockColor = [origBatteryFillColor(self, _cmd) colorWithAlphaComponent: 1];
+	stockColor = [origBFC(self, _cmd) colorWithAlphaComponent: 1];
 
 	[self updateColors];
 
@@ -234,7 +234,7 @@ __attribute__((constructor)) static void init() {
 
 	MSHookMessageEx(kClass(@"_UIBatteryView"), @selector(_commonInit), (IMP) &overrideCommonInit, (IMP *) &origCommonInit);
 	MSHookMessageEx(kClass(@"_UIBatteryView"), @selector(_shouldShowBolt), (IMP) &overrideSSB, (IMP *) NULL);
-	MSHookMessageEx(kClass(@"_UIBatteryView"), @selector(_batteryFillColor), (IMP) &overrideBFC, (IMP *) &origBatteryFillColor);
+	MSHookMessageEx(kClass(@"_UIBatteryView"), @selector(_batteryFillColor), (IMP) &overrideBFC, (IMP *) &origBFC);
 	MSHookMessageEx(kClass(@"_UIBatteryView"), @selector(bodyColor), (IMP) &overrideBC, (IMP *) NULL);
 	MSHookMessageEx(kClass(@"_UIBatteryView"), @selector(pinColor), (IMP) &overridePC, (IMP *) NULL);
 	MSHookMessageEx(kClass(@"_UIStatusBarStringView"), @selector(setText:), (IMP) &overrideSetText, (IMP *) &origSetText);

--- a/Objective-C/Tweak.m
+++ b/Objective-C/Tweak.m
@@ -24,6 +24,7 @@
 
 
 static float currentBattery;
+static BOOL isCharging;
 static UIColor* stockColor;
 
 #define kClass(string) NSClassFromString(string)
@@ -122,6 +123,18 @@ static void new_animateViewWithViews(
 		linearBar.backgroundColor = currentLinearColor;
 
 	} completion:nil];
+
+}
+
+
+static void (*origSetChargingState)(_UIBatteryView *self, SEL _cmd, NSInteger);
+
+static void overrideSetChargingState(_UIBatteryView *self, SEL _cmd, NSInteger state) {
+
+	origSetChargingState(self, _cmd, state);
+	isCharging = state == 1;
+
+	[self updateColors];
 
 }
 
@@ -233,6 +246,7 @@ static void new_setChargingBoltImageView(_UIBatteryView *self, SEL _cmd, UIImage
 __attribute__((constructor)) static void init() {
 
 	MSHookMessageEx(kClass(@"_UIBatteryView"), @selector(_commonInit), (IMP) &overrideCommonInit, (IMP *) &origCommonInit);
+	MSHookMessageEx(kClass(@"_UIBatteryView"), @selector(setChargingState:), (IMP) &overrideSetChargingState, (IMP *) &origSetChargingState);
 	MSHookMessageEx(kClass(@"_UIBatteryView"), @selector(_shouldShowBolt), (IMP) &overrideSSB, (IMP *) NULL);
 	MSHookMessageEx(kClass(@"_UIBatteryView"), @selector(_batteryFillColor), (IMP) &overrideBFC, (IMP *) &origBFC);
 	MSHookMessageEx(kClass(@"_UIBatteryView"), @selector(bodyColor), (IMP) &overrideBC, (IMP *) NULL);


### PR DESCRIPTION
This PR is a draft because I haven't changed the Swift code. Couldn't get it to run properly so you'll have to do it, or get it fixed for me.

This PR steals the fill color from the stock battery. Doing so fixes the following:
- iPads use the proper percentage for low battery (10% instead of 20%).
- Compatibility with Eliza (and other tweaks that change the battery color).
- Will ensure compatibility if iOS adds a new battery color.

This also greatly reduces code due to the following:
- Storage of LPM and charging state is now unnecessary, as such they have been removed and any code related to getting them has been removed.
- Code related to updating the color has been removed, because iOS tells us when to update the color.
- Code relating to figuring out the color has been removed because iOS does that for us.
- References to the colors to use were removed.

I've also fixed a bug I encountered when the iPad's "Not Charging" text wouldn't go away, by setting the percent check to an empty string instead of just returning.